### PR TITLE
Add base32 detection for macOS base64 decode rule

### DIFF
--- a/rules/macos/process_creation/proc_creation_macos_base64_decode.yml
+++ b/rules/macos/process_creation/proc_creation_macos_base64_decode.yml
@@ -14,10 +14,13 @@ logsource:
     category: process_creation
     product: macos
 detection:
-    selection:
+    selection_base64:
         Image: '/usr/bin/base64'
         CommandLine|contains: '-d'
-    condition: selection
+    selection_base32:
+        Image: '/usr/bin/base32'
+        CommandLine|contains: '-d'
+    condition: 1 of selection_*
 falsepositives:
     - Legitimate activities
 level: low


### PR DESCRIPTION
## Summary
- extend base64 decode rule to also detect base32 decoding on macOS

## Testing
- `python3 tests/test_logsource.py` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python3 tests/test_rules.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_687f151bddbc8325bc8f500c006535f6